### PR TITLE
We now export comparator types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,6 @@ mod comparator;
 mod iter_tournament;
 mod streaming_tournament;
 
-pub use comparator::Comparator;
+pub use comparator::*;
 pub use iter_tournament::Tournament;
 pub use streaming_tournament::StreamingTournament;


### PR DESCRIPTION
We have exported comparator types, otherwise it is impossible to return a Tournament.